### PR TITLE
Fixed incorrectly working *inc* function

### DIFF
--- a/mongodb.js
+++ b/mongodb.js
@@ -198,7 +198,8 @@ SqlBuilder.prototype.inc = function(name, type, value) {
 					break;
 			}
  		} else {
-	 		type = '+';
+			if(type !== '-')
+				type = '+';
  			if (value == null)
  				value = 1;
  		}


### PR DESCRIPTION
Bellow code leads to property some-prop being increased instead of decreased.
builder.inc('some-prop', '-', 1);
