### PR TITLE
Update sqlserver.js for queries w/o rows output

### DIFF
--- a/sqlserver.js
+++ b/sqlserver.js
@@ -1650,7 +1650,7 @@ Agent.prototype.$bind = function(item, err, rows) {
 		return;
 	}
 
-	if (!rows.length) {
+	if (!rows || !rows.length) {
 		if (item.type === 'insert') {
 			self.id = null;
 			if (!self.isPut)


### PR DESCRIPTION
Some MSSQL queries (when using sqlagent with sqlserver module) can return no rows. After that in Agent.prototype.$bind function rows === undefined and after that it's trying to get rows.length and throws NRE.
SQL Query sample for reproduce:
IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='products' AND xtype='U')
	CREATE TABLE products (
		...
	);