### PR TITLE
Added more types for casting in Postgres

### DIFF
--- a/pg.js
+++ b/pg.js
@@ -435,10 +435,14 @@ SqlBuilder.column = function(name, schema) {
 		switch (cast) {
 			case 'integer':
 			case 'int':
-			case 'byte':
 			case 'smallint':
 			case 'number':
 				cast = '::int';
+				break;
+			case 'byte':
+			case 'binary':
+			case 'bytea':
+				cast = '::bytea';
 				break;
 			case 'float':
 			case 'real':
@@ -450,6 +454,13 @@ SqlBuilder.column = function(name, schema) {
 			case 'boolean':
 			case 'bool':
 				cast = '::boolean';
+				break;
+			case 'text':
+			case 'varchar':
+			case 'character':
+			case 'char':
+			case 'string':
+				cast = '::text';
 				break;
 		}
 	}


### PR DESCRIPTION
Continuation of https://github.com/totaljs/node-sqlagent/issues/32

I found where you did the type casting in pg.js and added a few alternatives where they made sence to me. I ran into an issue with binary data that can't be cast to a integer in postgres. Also would like a string cast so can force it to text type if needed.

Separated out binary casting from integer (binary is stored as "bytea" which contains alpha characters).
Added in string casting to "text".

