### PR TITLE
Added error handling to connection pools for PostgreSQL

### DIFF
--- a/pg.js
+++ b/pg.js
@@ -1849,6 +1849,7 @@ Agent.prototype.exec = function(callback, returnIndex) {
 	(Agent.debug || self.debug) && console.log(self.debugname, '----- exec');
 
 	var pool = createpool(self.options);
+	pool.on('error', (err) => { console.log('Error during execution: ', err.code); });
 	pool.connect(function(err, client, done) {
 		if (err) {
 			Agent.error && Agent.error(err, 'driver');
@@ -1888,6 +1889,7 @@ Agent.prototype.writeStream = function(filestream, buffersize, callback) {
 	}
 
 	var pool = createpool(self.options);
+	pool.on('error', (err) => { console.log('Error during stream write: ', err.code); });
 	pool.connect(function(err, client, done) {
 
 		if (err) {
@@ -1928,6 +1930,7 @@ Agent.prototype.writeStream = function(filestream, buffersize, callback) {
 Agent.prototype.writeBuffer = function(buffer, callback) {
 	var self = this;
 	var pool = createpool(self.options);
+	pool.on('error', (err) => { console.log('Error during buffer write: ', err.code); });
 	pool.connect(function(err, client, done) {
 
 		if (err) {
@@ -1972,6 +1975,7 @@ Agent.prototype.readStream = function(oid, buffersize, callback) {
 	}
 
 	var pool = createpool(self.options);
+	pool.on('error', (err) => { console.log('Error during stream read: ', err.code); });
 	pool.connect(function(err, client, done) {
 
 		if (err) {


### PR DESCRIPTION
I was having issues where the application (sails.js in my case) would stop/crash due to uncaught error events being emitted by pg's pool system.

This was happening when the database is shutdown while a query is being actively run on it. I found the solution was to add these handlers for error events to the pools to catch and log them.

I was only getting an issue with the exec pool, but I added the same to the other pools for completeness. Feel free to alter the implementation or error messaging, I only need the error event to not be 'Unhandled' so the application doesn't stop. 

During testing I was still getting the normal errors coming through the promise rejections from the database so I hope this doesn't affect normal error generation.

@petersirka This is in extention to a small discussion we had a while back, ill add the emails here for reference.

> Hi Peter,
> Had an issue recently that required my server to be restarted and I’m currently investigating why (couldn't find any relevant errors). Currently I’m wondering if it's regarding sqlagent (12.0.3 is what is loaded). It's using a postgreSQL database(s); the issue that I'm suspecting to have happened is that the database the API was sending queries to didn't have logging setup correctly and didn't have any log file to write the error to. This caused a problem where an identical query could not be made, it just hangs without responding.
> 
> When I setup an identical API locally and make the same query to the same database it behaves as expected. I was able to make similar queries to other database using the trouble API while this was happening. Once I restarted the API it behaved correctly (had also corrected the database logging issue).
> 
> My connection here is that sqlagent takes the error(s) thrown by the database and passes them back to the caller of the agent/instance (the API). Is it possible that if the database didn't have anywhere to put the error, it couldn't be retrieved for sqlagent, so the query simply hangs indefinitely while waiting for the error? If this does seem like a possibility, I can put aside some time to create a test and make an issue about it (maybe even fix it if I can figure it out).
> 
> Regards,
> Aidan Dunn

> Hi,
> I have added something better error handling for unhandled errors from DB:
> Agent.error = function(err, type, query) {
>     console.log('PostgreSQL error', err, type, query);
> };
> Currently it will work with PG only. Just install a new beta version of SQL Agent: $ npm install sqlagent@beta .... But your application must be optimized for these unhandled cases. If the database isn't loaded correctly and the problem still persist in the app then the only one solution is to disable pooling (but as I see --> SQL Agent doesn't support it yet). I can modify it but within in Total.js Support or you can use our new module called DBMS: https://wiki.totaljs.com/dbms/01-welcome/
> 
> Thank you!
> 
> Peter Širka

I did try the suggested agent error handling as demonstraited without any success.

For a bit of information here is the error message that causes the application to stop:
```text
events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: read ECONNRESET
    at TCP.onStreamRead (internal/stream_base_commons.js:111:27)
Emitted 'error' event at:
    at Client.idleListener (path-to-application\node_modules\pg-pool\index.js:59:10)
    at Client.emit (events.js:182:13)
    at Client.EventEmitter.emit (domain.js:441:20)
    at Connection.connectedErrorHandler (path-to-application\node_modules\pg\lib\client.js:199:10)
    at Connection.emit (events.js:182:13)
    at Connection.EventEmitter.emit (domain.js:441:20)
    at Socket.reportStreamError (path-to-application\node_modules\pg\lib\connection.js:72:10)
    at Socket.emit (events.js:182:13)
    at Socket.EventEmitter.emit (domain.js:441:20)
    at emitErrorNT (internal/streams/destroy.js:82:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:50:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```
In the above situation, the code this commit adds should console.log value of `err.code` which would be "ECONNRESET".